### PR TITLE
Constrained version for mpdf/mpdf in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "mpdf/mpdf": "*"
+        "mpdf/mpdf": "<7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To be safe in the future when possible backwards uncompatible changes occur in mPDF codebase