### PR TITLE
bugfix for appending PDFs with version > 1.4

### DIFF
--- a/Pdf.php
+++ b/Pdf.php
@@ -377,7 +377,11 @@ class Pdf extends Component
      * @param String $attachement
      */
     private function writePdfAttachement ($api, $attachement){
-    	$pageCount = $api->SetSourceFile($attachement);
+    	try {
+    		$pageCount = $api->SetSourceFile($attachement);
+    	} catch (\MpdfException $e){
+    		$pageCount = 0;
+    	}
     	for($i=1; $i<=$pageCount; $i++){
     		$api->AddPage();
     		$templateId = $api->ImportPage($i);


### PR DESCRIPTION
When trying to append a PDF with version > 1.4, a MpdfException gets thrown by Mpdf. To have the generator function further on, the exception has to be catched and the problematic PDF simply doesn't get appended.