### PR TITLE
Correct Mpdf -> initContsructorParams margin parsing.

### DIFF
--- a/Pdf.php
+++ b/Pdf.php
@@ -287,12 +287,12 @@ class Pdf extends Component
         $this->options['format'] = $this->format;
         $this->options['default_font_size'] = $this->defaultFontSize;
         $this->options['default_font'] = $this->defaultFont;
-        $this->options['mgl'] = $this->marginLeft;
-        $this->options['mgr'] = $this->marginRight;
-        $this->options['mgt'] = $this->marginTop;
-        $this->options['mgb'] = $this->marginBottom;
-        $this->options['mgh'] = $this->marginHeader;
-        $this->options['mgf'] = $this->marginFooter;
+        $this->options['margin_left'] = $this->marginLeft;
+        $this->options['margin_right'] = $this->marginRight;
+        $this->options['margin_top'] = $this->marginTop;
+        $this->options['margin_bottom'] = $this->marginBottom;
+        $this->options['margin_header'] = $this->marginHeader;
+        $this->options['margin_footer'] = $this->marginFooter;
         $this->options['orientation'] = $this->orientation;
         if (isset($this->tempPath) && is_dir($this->tempPath)) {
             $this->options['tempDir'] = $this->tempPath;


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-mpdf/blob/master/CHANGE.md)):

Correct Mpdf -> initContsructorParams margin parsing.

https://github.com/mpdf/mpdf/blob/development/src/Mpdf.php#L1543 :
```php
private function initConstructorParams(array $config)
  {
    $constructor = [
      'mode' => '',
      'format' => 'A4',
      'default_font_size' => 0,
      'default_font' => '',
      'margin_left' => 15,
      'margin_right' => 15,
      'margin_top' => 16,
      'margin_bottom' => 16,
      'margin_header' => 9,
      'margin_footer' => 9,
      'orientation' => 'P',
    ];

    foreach ($constructor as $key => $val) {
      if (isset($config[$key])) {
        $constructor[$key] = $config[$key];
      }
    }

    return array_values($constructor);
  }
```


## Versions

**mpdf/mpdf**
7.0.x-dev `4b5f88f`

**kartik-v/yii2-mpdf**
dev-master `5f3cf0d`