### PR TITLE
Fixed bug with $this->buffer

### DIFF
--- a/Pdf.php
+++ b/Pdf.php
@@ -418,7 +418,7 @@ class Pdf extends Component
 
 		if (!isset($_SERVER['HTTP_ACCEPT_ENCODING']) || empty($_SERVER['HTTP_ACCEPT_ENCODING'])) {
 			// don't use length if server using compression
-			$headers->set('Content-Length', strlen($this->buffer));
+			$headers->set('Content-Length', strlen($output));
 		}
 
 		if ($dest == self::DEST_BROWSER) {


### PR DESCRIPTION
Variable $this->buffer is undefined!

## Scope
This pull request includes a

- Bug fix

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-mpdf/blob/master/CHANGE.md)):

- Fixed undefined variable $this->buffer

## Related Issues
If this is related to an existing ticket, include a link to it as well.