### PR TITLE
Fix getCss function

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -306,18 +306,21 @@ class Pdf extends Component
         if (!empty($this->_css)) {
             return $this->_css;
         }
-        $css = '';
-        $cssFiles = is_array($this->cssFile) ? $this->cssFile : [$this->cssFile];
-        foreach($cssFiles as $cssFile) {
-            $cssFile = Yii::getAlias($cssFile);
-            if (!empty($cssFile) && file_exists($cssFile)) {
-                $css .= file_get_contents($cssFile);
-            } else {
-                throw new InvalidConfigException("CSS File not found: '{$cssFile}'.");
+	    $this->_css = '';
+        if (!empty($this->cssFile)) {
+            $cssFiles = is_array($this->cssFile) ? $this->cssFile : [$this->cssFile];
+            foreach ($cssFiles as $cssFile) {
+                $cssFile = Yii::getAlias($cssFile);
+                if (!empty($cssFile) && file_exists($cssFile)) {
+                    $this->_css .= file_get_contents($cssFile);
+                }
+                else {
+                    throw new InvalidConfigException("CSS File not found: '{$cssFile}'.");
+                }
             }
         }
-        $css .= $this->cssInline;
-        return $css;
+	    $this->_css .= $this->cssInline;
+        return $this->_css;
     }
 
     /**


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-mpdf/blob/master/CHANGE.md)):

- If $this->cssFile is null or empty, an error occurs "CSS File not found"
- The $this->_css variable is not used

## Related Issues
If this is related to an existing ticket, include a link to it as well.