### PR TITLE
Fix #111: Update docs to mention cssFile can be an array or a string

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -143,7 +143,7 @@ class Pdf extends Component
      */
     public $orientation = self::ORIENT_PORTRAIT;
     /**
-     * @var string css file to prepend to the PDF
+     * @var array|string css files to prepend to the PDF
      */
     public $cssFile = '@vendor/kartik-v/yii2-mpdf/src/assets/kv-mpdf-bootstrap.min.css';
     /**


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix (not sure..., its just phpdoc)
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-mpdf/blob/master/CHANGE.md)):

- #111 document that $cssFile can also be an array

## Related Issues
If this is related to an existing ticket, include a link to it as well.