### PR TITLE
Bump mpdf version to ~8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "mpdf/mpdf": "~8.0"
+        "mpdf/mpdf": "~8.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] bump mpdf version

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-mpdf/blob/master/CHANGE.md)):

- upgrade mpdf version from ~8.0 to ~8.1
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.